### PR TITLE
server proxy

### DIFF
--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,0 +1,12 @@
+# This is sh (dash) by default, not $SHELL
+c.NotebookApp.terminado_settings = { "shell_command": ["bash"] }
+
+c.ServerProxy.servers = {
+  'http-server': {
+    'command': ['python3', '-m', 'http.server', '{port}'],
+    'absolute_url': False,
+    'launcher_entry': {
+      'title': "HTTP Server"
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 pandas
 jupyter-book==0.8.0
 ruamel.yaml
+jupyter-server-proxy


### PR DESCRIPTION
I believe that this should get an `http.server` working with this repository on Binder.

Once you launch a session, you should be able to see it in the launch menu:

![image](https://user-images.githubusercontent.com/1839645/94937576-9a8c1d00-0484-11eb-9b39-093023c74248.png)

Try it out at the link here: https://gesis.mybinder.org/binder/v2/gh/choldgraf/jupytercon_tutorial/490ca906164922e1fedfd862a58c2cdad2783941
